### PR TITLE
Custom transformer types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Changelog
 
-## v0.1.0
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Initial release.
+## v0.4.0
 
-## v0.2.0
-
-Adds support for default `type` of `:string` to the `Dotenvy.env!/2` and `Dotenvy.env/3` functions.
+- Adds support for custom transformer types by allowing an arity 1 function as the second argument to `Dotenvy.Transformer.to/2`. See [Issue 2](https://github.com/fireproofsocks/dotenvy/issues/2)
 
 ## v0.3.0
 
@@ -15,3 +14,11 @@ Adds support for default `type` of `:string` to the `Dotenvy.env!/2` and `Dotenv
 - Tracks an error if the `:require_files` option lists a file not included in the `files` input (for sanity).
 - Introduces `Dotenvy.env!/3` (which is the same as `Dotenvy.env/3` but with no defaults provided). This better communicates that it may raise an error (because internally it relies on `Dotenvy.Transformer.to!/2`)
 - Deprecates `Dotenvy.env/3` in favor of `Dotenvy.env!/3`
+
+## v0.2.0
+
+Adds support for default `type` of `:string` to the `Dotenvy.env!/2` and `Dotenvy.env/3` functions.
+
+## v0.1.0
+
+Initial release.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License](https://img.shields.io/hexpm/l/dotenvy.svg)](https://hex.pm/packages/dotenvy)
 [![Last Updated](https://img.shields.io/github/last-commit/fireproofsocks/dotenvy.svg)](https://github.com/fireproofsocks/dotenvy/commits/master)
 
-`Dotenvy` is an Elixir implementation of the original [dotenv](https://github.com/bkeepers/dotenv) Ruby gem, **compatible with mix and releases**. It is designed to help the development of applications following the principles of the [12-factor app](https://12factor.net/) and its recommendation to store configuration in the environment.
+`Dotenvy` is an Elixir port of the original [dotenv](https://github.com/bkeepers/dotenv) Ruby gem, **compatible with mix and releases**. It is designed to help the development of applications following the principles of the [12-factor app](https://12factor.net/) and its recommendation to store configuration in the environment.
 
 ## Installation
 

--- a/lib/dotenvy.ex
+++ b/lib/dotenvy.ex
@@ -1,6 +1,6 @@
 defmodule Dotenvy do
   @moduledoc """
-  `Dotenvy` is an Elixir implementation of the original [dotenv](https://github.com/bkeepers/dotenv) Ruby gem.
+  `Dotenvy` is an Elixir port of the original [dotenv](https://github.com/bkeepers/dotenv) Ruby gem.
 
   It is designed to help the development of applications following the principles of
   the [12-factor app](https://12factor.net/) and its recommendation to store

--- a/lib/dotenvy/transformer.ex
+++ b/lib/dotenvy/transformer.ex
@@ -58,6 +58,12 @@ defmodule Dotenvy.Transformer do
   - `:string` - no conversion (default)
   - `:string?` - empty strings will be considered `nil`.
   - `:string!` - as above, but an empty string will raise.
+  - custom function - see below.
+
+  ## Custom Callback function
+
+  When you require more control over the transformation of your value than is possible
+  with the types provided, you can provide an arity 1 function in place of the type.
 
   ## Examples
 
@@ -69,6 +75,8 @@ defmodule Dotenvy.Transformer do
       nil
       iex> to!("5432", :integer)
       5432
+      iex> to!("foo", fn val -> val <> "bar" end)
+      "foobar"
   """
   @spec to!(str :: binary(), type :: atom) :: any()
   def to!(str, :atom) when is_binary(str) do
@@ -147,6 +155,10 @@ defmodule Dotenvy.Transformer do
   def to!(str, :string?) when is_binary(str), do: str
   def to!("", :string!), do: raise(Error)
   def to!(str, :string!) when is_binary(str), do: str
+
+  def to!(str, callback) when is_function(callback, 1) do
+    callback.(str)
+  end
 
   def to!(str, _) when not is_binary(str), do: raise(Error, "Input must be a string.")
   def to!(_, type), do: raise(Error, "Unknown type #{inspect(type)}")

--- a/mix.exs
+++ b/mix.exs
@@ -39,9 +39,8 @@ defmodule Dotenvy.MixProject do
 
   defp description do
     """
-    Dotenvy is an Elixir implementation of the original dotenv Ruby gem, compatible
-    with mix and releases. It is designed to facilitate runtime configuration per the
-    guidelines of the 12-factor App.
+    A port of the original dotenv Ruby gem, for mix and releases.
+    Facilitates runtime config per the 12-factor App.
     """
   end
 

--- a/test/dotenvy/transformer_test.exs
+++ b/test/dotenvy/transformer_test.exs
@@ -255,6 +255,12 @@ defmodule Dotenvy.TransformerTest do
     end
   end
 
+  describe "to!/2 custom callback function" do
+    test "do custom modification" do
+      assert "foobar" == T.to!("foo", fn val -> "#{val}bar" end)
+    end
+  end
+
   describe "to!/2 errors" do
     test "unsupported type" do
       assert_raise Dotenvy.Transformer.Error, fn ->


### PR DESCRIPTION
This PR does some documentation cleanup, but primarily it adds the ability to supply a custom transformation via an arity 1 function provided to `to!/2`.