### PR TITLE
Improved error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.4.1
+
+- Makes error messages more informative when unable to convert strings to integers or floats
+
 ## v0.4.0
 
 - Adds support for custom transformer types by allowing an arity 1 function as the second argument to `Dotenvy.Transformer.to/2`. See [Issue 2](https://github.com/fireproofsocks/dotenvy/issues/2)

--- a/lib/dotenvy.ex
+++ b/lib/dotenvy.ex
@@ -108,7 +108,7 @@ defmodule Dotenvy do
     end
   rescue
     error in Error ->
-      reraise "Error converting #{variable} to #{type}: #{error.message}", __STACKTRACE__
+      reraise "Error converting variable #{variable} to #{type}: #{error.message}", __STACKTRACE__
 
     error ->
       reraise error, __STACKTRACE__

--- a/lib/dotenvy/transformer.ex
+++ b/lib/dotenvy/transformer.ex
@@ -12,7 +12,7 @@ defmodule Dotenvy.Transformer do
   end
 
   @doc """
-  Converts strings into Elixir data types with support for nil-able values.
+  Converts strings into Elixir data types with support for nil-able values. Raises on error.
 
   Each type determines how to interpret the incoming string, e.g. when the `type`
   is `:integer`, an empty string is considered a `0`; when `:integer?` is the `type`,
@@ -127,14 +127,34 @@ defmodule Dotenvy.Transformer do
   def to!(str, :existing_atom!), do: to!(str, :existing_atom)
 
   def to!("", :float), do: 0
-  def to!(str, :float) when is_binary(str), do: String.to_float(str)
+
+  def to!(str, :float) when is_binary(str) do
+    case Float.parse(str) do
+      :error ->
+        raise(Error, "Unparsable")
+
+      {value, _} ->
+        value
+    end
+  end
+
   def to!("", :float?), do: nil
   def to!(str, :float?), do: to!(str, :float)
   def to!("", :float!), do: raise(Error)
   def to!(str, :float!), do: to!(str, :float)
 
   def to!("", :integer), do: 0
-  def to!(str, :integer) when is_binary(str), do: String.to_integer(str)
+
+  def to!(str, :integer) when is_binary(str) do
+    case Integer.parse(str) do
+      :error ->
+        raise(Error, "Unparsable")
+
+      {value, _} ->
+        value
+    end
+  end
+
   def to!("", :integer?), do: nil
   def to!(str, :integer?), do: to!(str, :integer)
   def to!("", :integer!), do: raise(Error)

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Dotenvy.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/fireproofsocks/dotenvy"
-  @version "0.4.0"
+  @version "0.4.1"
 
   def project do
     [

--- a/test/dotenvy/transformer_test.exs
+++ b/test/dotenvy/transformer_test.exs
@@ -139,6 +139,12 @@ defmodule Dotenvy.TransformerTest do
     test "empty string to zero" do
       assert 0 = T.to!("", :float)
     end
+
+    test "raises on unparsable" do
+      assert_raise Dotenvy.Transformer.Error, fn ->
+        T.to!("Abc", :float)
+      end
+    end
   end
 
   describe "to!/2 :float?" do
@@ -174,6 +180,12 @@ defmodule Dotenvy.TransformerTest do
 
     test "negative" do
       assert -123 = T.to!("-123", :integer)
+    end
+
+    test "raises on unparsable" do
+      assert_raise Dotenvy.Transformer.Error, fn ->
+        T.to!("Abc", :integer)
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds better error messaging for cases when a string cannot be converted to an integer or float.
Parsing errors should now be seen with a message something like:
```
** (RuntimeError) Error converting variable FOO to integer: Unparsable
    (dotenvy 0.4.1) lib/dotenvy/transformer.ex:151: Dotenvy.Transformer.to!/2
    (dotenvy 0.4.1) lib/dotenvy.ex:107: Dotenvy.env!/2
```
This resolves issue #5 