### PR TITLE
Refactor storage: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.5.0
+
+- Shifts storage of system environment variables to the application process dictionary and alters the reading of this data to help improve the security posture and avoid leaking env values. `:side_effect` option for `source/2` and `source!/2` function changed.
+
 ## v0.4.1
 
 - Makes error messages more informative when unable to convert strings to integers or floats

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ POOL_SIZE=10
 POOL=
 ```
 
-When you set up your application configuration in this way, you are creating a contract with the environment (errors will be raised if certain system variables are not set because `Dotenvy.env!/2` relies on `System.fetch_env!/1`), and this is an approach that works equally well for your day-to-day development and testing, as well as for mix releases.
+When you set up your application configuration in this way, you are creating a contract with the environment: `Dotenvy.env!/2` will raise if the required variables have not been set or if the values cannot be properly tranformed. This is an approach that works equally well for your day-to-day development and testing, as well as for mix releases.
 
 Read the [configuration strategies](docs/strategies.md) for more detailed examples of how to configure your app.
 

--- a/lib/dotenvy.ex
+++ b/lib/dotenvy.ex
@@ -57,7 +57,6 @@ defmodule Dotenvy do
       iex> env!("NOT_SET", :boolean, %{not: "converted"})
       %{not: "converted"}
       iex> System.put_env("HOST", "")
-      iex> source([".env", ...])
       iex> env!("HOST", :string!, "localhost")
       ** (RuntimeError) Error converting HOST to string!: non-empty value required
   """

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Dotenvy.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/fireproofsocks/dotenvy"
-  @version "0.4.1"
+  @version "0.5.0"
 
   def project do
     [

--- a/test/dotenvy_test.exs
+++ b/test/dotenvy_test.exs
@@ -12,14 +12,14 @@ defmodule DotenvyTest do
     end
 
     test "returns value when env set", %{test: test} do
-      source([], vars: %{"TEST_VALUE" => "#{test}"})
+      System.put_env("TEST_VALUE", "#{test}")
       assert "#{test}" == env!("TEST_VALUE", :string, nil)
     end
   end
 
   describe "env!/2" do
     test "default type is string", %{test: test} do
-      source([], vars: %{"TEST_VALUE" => "#{test}"})
+      System.put_env("TEST_VALUE", "#{test}")
       assert "#{test}" == env!("TEST_VALUE")
     end
 

--- a/test/dotenvy_test.exs
+++ b/test/dotenvy_test.exs
@@ -12,14 +12,14 @@ defmodule DotenvyTest do
     end
 
     test "returns value when env set", %{test: test} do
-      System.put_env("TEST_VALUE", "#{test}")
+      source([], vars: %{"TEST_VALUE" => "#{test}"})
       assert "#{test}" == env!("TEST_VALUE", :string, nil)
     end
   end
 
   describe "env!/2" do
     test "default type is string", %{test: test} do
-      System.put_env("TEST_VALUE", "#{test}")
+      source([], vars: %{"TEST_VALUE" => "#{test}"})
       assert "#{test}" == env!("TEST_VALUE")
     end
 
@@ -40,9 +40,9 @@ defmodule DotenvyTest do
                source(["test/support/files/a.env", "test/support/files/b.env"], vars: %{})
     end
 
-    test "sets system env vars" do
+    test "system env vars not set" do
       assert {:ok, _} = source(["test/support/files/a.env"])
-      assert "ball" == System.get_env("B")
+      assert :error == System.fetch_env("B")
     end
 
     test "enforces list of :require_files" do


### PR DESCRIPTION
This PR refactors the side-effect used by the `Dotenvy.source/2` and `source!/2` functions so that it stores the merged values inside the `Application` process dictionary instead of inside the `System`.  Internally, this now does this: `Application.put_env(:dotenvy, :vars, source_vars)`

This should improve the security posture of the app because it no longer "leaks" values back into the system environment.

Note that this PR does not deal with the cleanup of the variables set inside `Application`; it's a bit weird that you can simply do `Application.put_env(:some_arbitrary_app, :key, "value")`... the app doesn't need to be exist.