### PR TITLE
Add type modifier '_no_fall_back' to prevent fallback to system env

### DIFF
--- a/lib/dotenvy/transformer.ex
+++ b/lib/dotenvy/transformer.ex
@@ -46,6 +46,14 @@ defmodule Dotenvy.Transformer do
   - `:string!` - as above, but an empty string will raise.
   - custom function - see below.
 
+  ## Prevent Fallback to System Environment
+
+  If a variable is not found when calling `Dotenvy.env!/2` or `Dotenvy.env!/3`, the code will
+  check if there is a system environment variable with a matching name, and return (i.e. fall back
+  to) this value if it exists. This behaviour can be overridden by adding a "`_no_fall_back`"
+  modifier to the specified type (e.g. `:string_no_fall_back!`) when calling `Dotenvy.env!/2` or
+  `Dotenvy.env!/3`. Any atom type can use this modifier.
+
   ## Custom Callback function
 
   When you require more control over the transformation of your value than is possible

--- a/test/dotenvy_test.exs
+++ b/test/dotenvy_test.exs
@@ -16,6 +16,14 @@ defmodule DotenvyTest do
       assert "#{test}" == env!("TEST_VALUE", :string, nil)
     end
 
+    test "does not return env value when 'no fall back' type modifier set", %{test: test} do
+      System.put_env("TEST_VALUE", "#{test}")
+
+      assert_raise RuntimeError, fn ->
+        env!("TEST_VALUE", :string_no_fall_back!)
+      end
+    end
+
     test "built-in conversion errors convert to RuntimeError", %{test: test} do
       System.put_env("TEST_VALUE", "#{test}")
 


### PR DESCRIPTION
An attempt at fixing #21. (An alternative implementation can be found at #23.)

Adds a modifier for the atom types called `_no_fall_back` (e.g. `:string_no_fall_back`). If present, this value will ensure that the code does not attempt to fall back to the use of the system environment when a dotenv variable is not found, but will instead raise.

It is intended to guard against scenarios where environment variables are unexpectedly set (e.g. the `POSTGRES_HOST` env var is automatically set to `tcp://172.17.0.3:5432` in a Docker container, which is both unexpected and in an invalid format compared to what my repo config expects).

It is backwards compatible and should not break any existing code. A short test has been added to ensure the function acts as intended.

I'll be the first to admit that this pull request does not offer the most elegant mechanism of specifying "no fallback" values, but it does preserve backwards compatibility and would allow the next release to be a SemVer minor upgrade, while any other implementations would probably break existing code. Based on the current implementation, there are not a lot of ways that I could see to implement this feature in a backwards-compatible manner.