### PR TITLE
Remove automatic fallback to system env

### DIFF
--- a/lib/dotenvy.ex
+++ b/lib/dotenvy.ex
@@ -84,8 +84,7 @@ defmodule Dotenvy do
   Conversion is delegated to `Dotenvy.Transformer.to!/2`, which may raise an error.
   See its documentation for a list of supported types.
 
-  This function attempts to read a value from a local data store of sourced values;
-  it will fall back to `System.fetch_env/1` when no locally stored variable is available.
+  This function attempts to read a value from a local data store of sourced values.
 
   ## Examples
 
@@ -133,8 +132,7 @@ defmodule Dotenvy do
   @doc """
   Reads the given env `variable` and converts its value to the given `type`.
 
-  This function attempts to read a value from a local data store of sourced values;
-  it will fall back to `System.fetch_env/1` when no locally stored variable is available.
+  This function attempts to read a value from a local data store of sourced values.
 
   This function may raise an error because type conversion is delegated to
   `Dotenvy.Transformer.to!/2` -- see its documentation for a list of supported types.
@@ -152,7 +150,7 @@ defmodule Dotenvy do
 
   def env!(variable, type) do
     case fetch_var(variable) do
-      :error -> raise "Application environment variable #{variable} not set"
+      :error -> raise "Dotenv variable #{variable} not set"
       {:ok, value} -> to!(value, type)
     end
   rescue
@@ -305,10 +303,6 @@ defmodule Dotenvy do
     :dotenvy_vars
     |> Process.get(%{})
     |> Map.fetch(variable)
-    |> case do
-      {:ok, value} -> {:ok, value}
-      :error -> System.fetch_env(variable)
-    end
   end
 
   defp put_all_vars(vars), do: Process.put(:dotenvy_vars, vars)

--- a/test/dotenvy_test.exs
+++ b/test/dotenvy_test.exs
@@ -11,13 +11,20 @@ defmodule DotenvyTest do
       assert "some-default" = env!("DOES_NOT_EXIST", :string, "some-default")
     end
 
-    test "returns value when env set", %{test: test} do
+    test "returns value when env set and sourced", %{test: test} do
       System.put_env("TEST_VALUE", "#{test}")
+
+      assert_raise RuntimeError, fn ->
+        env!("TEST_VALUE", :string)
+      end
+
+      source([System.get_env()])
       assert "#{test}" == env!("TEST_VALUE", :string, nil)
     end
 
     test "built-in conversion errors convert to RuntimeError", %{test: test} do
       System.put_env("TEST_VALUE", "#{test}")
+      source([System.get_env()])
 
       assert_raise RuntimeError, fn ->
         env!("TEST_VALUE", :integer, 123)
@@ -26,6 +33,7 @@ defmodule DotenvyTest do
 
     test "raising Dotenvy.Error with custom message converts to RuntimeError", %{test: test} do
       System.put_env("TEST_VALUE", "#{test}")
+      source([System.get_env()])
 
       assert_raise RuntimeError, ~r/Custom error/, fn ->
         env!(
@@ -40,6 +48,7 @@ defmodule DotenvyTest do
 
     test "raising other error types passes thru", %{test: test} do
       System.put_env("TEST_VALUE", "#{test}")
+      source([System.get_env()])
 
       assert_raise FunctionClauseError, fn ->
         env!("TEST_VALUE", fn _ -> Keyword.get(%{}, :foo) end, "default")
@@ -50,6 +59,7 @@ defmodule DotenvyTest do
   describe "env!/2" do
     test "default type is string", %{test: test} do
       System.put_env("TEST_VALUE", "#{test}")
+      source([System.get_env()])
       assert "#{test}" == env!("TEST_VALUE")
     end
 
@@ -61,6 +71,7 @@ defmodule DotenvyTest do
 
     test "built-in conversion errors convert to RuntimeError", %{test: test} do
       System.put_env("TEST_VALUE", "#{test}")
+      source([System.get_env()])
 
       assert_raise RuntimeError, fn ->
         env!("TEST_VALUE", :integer)
@@ -69,6 +80,7 @@ defmodule DotenvyTest do
 
     test "raising Dotenvy.Error with custom message converts to RuntimeError", %{test: test} do
       System.put_env("TEST_VALUE", "#{test}")
+      source([System.get_env()])
 
       assert_raise RuntimeError, ~r/Custom error/, fn ->
         env!("TEST_VALUE", fn _ ->
@@ -79,6 +91,7 @@ defmodule DotenvyTest do
 
     test "raising other error types passes thru", %{test: test} do
       System.put_env("TEST_VALUE", "#{test}")
+      source([System.get_env()])
 
       assert_raise FunctionClauseError, fn ->
         env!("TEST_VALUE", fn _ -> Keyword.get(%{}, :foo) end)


### PR DESCRIPTION
This pull request is intended to resolve #21 (either this pull request or #22 will resolve the issue). I made it in response to @lud's suggestion that the fallback behavior could be removed altogether.

Fallback to system env can be enabled by including `System.get_env()` in the list of values passed to `Dotenvy.source/2` or `Dotenvy.source!/2`.